### PR TITLE
Add `sessionId` support for the visit & link click helpers

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -2,7 +2,10 @@
 
 class AppController {
   constructor() {
-    this.backendURL = 'https://push-notifications-server.glitch.me';
+    const isLocalhost = location.hostname === 'localhost';
+    const BACKEND_URL = isLocalhost ? 'http://localhost:8080' : 'https://push-notifications-server.glitch.me';
+
+    this.backendURL = BACKEND_URL;
 
     this.registration = null;
     this.subscription = null;

--- a/docs/styles/visits.css
+++ b/docs/styles/visits.css
@@ -1,0 +1,262 @@
+body {
+  font-family: 'Roboto', -apple-system, BlinkMacSystemFont, sans-serif;
+  max-width: 100%;
+  margin: 0 auto;
+  padding: 20px;
+  background-color: #f5f5f5;
+  overflow-x: hidden;
+}
+
+h1 {
+  color: #1a73e8;
+  font-weight: 400;
+}
+
+.table-container {
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+table {
+  width: 100%;
+  min-width: 800px;
+  border-collapse: collapse;
+  background: white;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+  margin: 20px 0;
+}
+
+th, td {
+  padding: 16px;
+  text-align: left;
+  max-width: 200px;
+  overflow: hidden;
+  word-wrap: break-word;
+  border-bottom: 1px solid #eeeeee;
+}
+
+th {
+  background-color: #1a73e8;
+  color: white;
+  font-weight: 500;
+  text-transform: uppercase;
+  font-size: 0.875rem;
+  letter-spacing: 0.5px;
+}
+
+tr:hover {
+  background-color: #f5f5f5;
+}
+
+button {
+  background-color: #dc3545;
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s;
+}
+
+button:hover {
+  background-color: #c82333;
+}
+
+p {
+  color: #5f6368;
+  font-size: 0.9rem;
+}
+
+/* Link clicks styles */
+.link-clicks-cell {
+  padding: 0 !important;
+}
+
+.link-clicks-toggle {
+  background: #1a73e8;
+  color: white;
+  border: none;
+  padding: 16px;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+}
+
+.link-clicks-toggle:hover {
+  background: #1557b0;
+}
+
+.link-clicks-content {
+  display: none;
+}
+
+.link-clicks-content.active {
+  display: table;
+  width: 100%;
+}
+
+.link-clicks-table {
+  width: 100%;
+  border-top: 1px solid #eee;
+}
+
+.link-clicks-table td {
+  background: #f8f9fa;
+  font-size: 0.9em;
+}
+
+.link-clicks-table th {
+  background: #e8eaed;
+  color: #000;
+  font-size: 0.8em;
+  text-transform: uppercase;
+}
+
+.link-clicks-row {
+  display: none;
+}
+
+.link-clicks-row.active {
+  display: table-row;
+}
+
+.link-clicks-cell {
+  padding: 0 !important;
+}
+
+.link-clicks-toggle {
+  background: #1a73e8;
+  color: white;
+  border: none;
+  padding: 16px;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+}
+
+.link-clicks-toggle:hover {
+  background: #1557b0;
+}
+
+.link-clicks-content {
+  display: none;
+}
+
+.link-clicks-content.active {
+  display: table;
+  width: 100%;
+}
+
+.link-clicks-table {
+  width: 100%;
+  border-top: 1px solid #eee;
+}
+
+.link-clicks-table td {
+  background: #f8f9fa;
+  font-size: 0.9em;
+}
+
+.link-clicks-table th {
+  background: #e8eaed;
+  color: #000;
+  font-size: 0.8em;
+  text-transform: uppercase;
+}
+
+.link-clicks-row {
+  display: none;
+}
+
+.link-clicks-row.active {
+  display: table-row;
+}
+
+@media screen and (max-width: 1000px) {
+  table, thead, tbody, tr, th, td {
+    display: block;
+  }
+
+  thead tr {
+    position: absolute;
+    top: -9999px;
+    left: -9999px;
+  }
+
+  tr {
+    margin-bottom: 2rem;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.12);
+    border-radius: 8px;
+    background: white;
+  }
+
+  td {
+    position: relative;
+    padding-left: 50%;
+    border: none;
+    border-bottom: 1px solid #eee;
+  }
+
+  td:before {
+    position: absolute;
+    left: 16px;
+    width: 45%;
+    padding-right: 10px;
+    font-weight: 500;
+    color: #1a73e8;
+  }
+
+  /* Add labels for each cell */
+  td:nth-of-type(1):before { content: "#"; }
+  td:nth-of-type(2):before { content: "Country"; }
+  td:nth-of-type(3):before { content: "City"; }
+  td:nth-of-type(4):before { content: "Region"; }
+  td:nth-of-type(5):before { content: "ISP"; }
+  td:nth-of-type(6):before { content: "IP"; }
+  td:nth-of-type(7):before { content: "Referrer"; }
+  td:nth-of-type(8):before { content: "Full URL"; }
+  td:nth-of-type(9):before { content: "Date"; }
+  td:nth-of-type(10):before { content: "Link Clicks"; }
+  td:nth-of-type(11):before { content: "Actions"; }
+
+  /* Special handling for link clicks cell */
+  .link-clicks-cell {
+    padding: 0 !important;
+    display: flex !important;
+    justify-content: flex-end;
+  }
+
+  .link-clicks-toggle {
+    width: auto;
+    margin: 8px 16px;
+    border-radius: 4px;
+  }
+
+  /* Adjust the expanded link clicks row */
+  .link-clicks-row td {
+    padding: 0;
+  }
+
+  .link-clicks-row {
+    margin-bottom: 0;
+    box-shadow: none;
+  }
+
+  .link-clicks-table {
+    margin: 8px 16px;
+    border-radius: 4px;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.12);
+  }
+
+  .link-clicks-table td {
+    padding-left: 50%;
+  }
+
+  .link-clicks-table td:nth-of-type(1):before { content: "Link Text"; }
+  .link-clicks-table td:nth-of-type(2):before { content: "Click Time"; }
+}

--- a/docs/styles/visits.css
+++ b/docs/styles/visits.css
@@ -181,20 +181,21 @@ p {
     display: block;
   }
 
-  thead tr {
-    position: absolute;
-    top: -9999px;
-    left: -9999px;
+  thead {
+    display: none;
   }
 
   tr {
-    margin-bottom: 2rem;
+    margin-bottom: 1rem;
     box-shadow: 0 1px 3px rgba(0,0,0,0.12);
     border-radius: 8px;
     background: white;
+    cursor: pointer;
+    transition: all 0.3s ease;
   }
 
   td {
+    display: none;
     position: relative;
     padding-left: 50%;
     border: none;
@@ -225,38 +226,144 @@ p {
 
   /* Special handling for link clicks cell */
   .link-clicks-cell {
-    padding: 0 !important;
-    display: flex !important;
-    justify-content: flex-end;
+    padding: 16px !important;
+    padding-left: 50% !important;
   }
 
   .link-clicks-toggle {
     width: auto;
-    margin: 8px 16px;
+    margin: 0;
     border-radius: 4px;
   }
 
   /* Adjust the expanded link clicks row */
-  .link-clicks-row td {
-    padding: 0;
+  .link-clicks-row {
+    margin: 0;
+    box-shadow: none;
+    border-radius: 0;
   }
 
-  .link-clicks-row {
-    margin-bottom: 0;
-    box-shadow: none;
+  .link-clicks-row td {
+    padding: 0 16px 16px 16px !important;
   }
 
   .link-clicks-table {
-    margin: 8px 16px;
+    display: table;
+    width: 100%;
+    background: white;
+    margin: 8px 0;
     border-radius: 4px;
     overflow: hidden;
     box-shadow: 0 1px 3px rgba(0,0,0,0.12);
   }
 
-  .link-clicks-table td {
-    padding-left: 50%;
+  .link-clicks-table thead {
+    display: table-header-group;
   }
 
-  .link-clicks-table td:nth-of-type(1):before { content: "Link Text"; }
-  .link-clicks-table td:nth-of-type(2):before { content: "Click Time"; }
+  .link-clicks-table tbody {
+    display: table-row-group;
+  }
+
+  .link-clicks-table tr {
+    display: table-row;
+  }
+
+  .link-clicks-table th,
+  .link-clicks-table td {
+    display: table-cell;
+    padding: 12px 16px;
+    width: auto;
+    border: none;
+  }
+
+  /* Remove any pseudo-elements from the link clicks table */
+  .link-clicks-table td:before,
+  .link-clicks-table th:before {
+    display: none;
+  }
+
+  /* Show only city cell by default */
+  td:nth-of-type(3) {
+    display: block;
+    padding: 16px;
+    padding-left: 50%;
+    font-size: 1.1em;
+    font-weight: 500;
+  }
+
+  td:nth-of-type(3):after {
+    content: '\25BC';  /* Unicode for black down-pointing triangle */
+    position: absolute;
+    right: 16px;
+    top: 50%;
+    transform: translateY(-50%);
+    transition: transform 0.3s ease;
+    color: #1a73e8;
+  }
+
+  tr.expanded td {
+    display: block; /* Show all cells when expanded */
+  }
+
+  tr.expanded td:nth-of-type(3):after {
+    transform: translateY(-50%) rotate(180deg);
+  }
+
+  /* Link clicks styles for mobile */
+  .link-clicks-row {
+    display: none;
+    margin: 0;
+    background: none;
+    box-shadow: none;
+    width: 100%;
+  }
+
+  .link-clicks-row.active {
+    display: block;
+    height: auto;
+    overflow: visible;
+  }
+
+  .link-clicks-row td {
+    display: block;
+    width: 100%;
+    padding: 16px !important;
+  }
+
+  .link-clicks-table {
+    display: table;
+    width: 100%;
+    background: white;
+    margin: 8px 0;
+    border-radius: 4px;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.12);
+  }
+
+  .link-clicks-table thead {
+    display: table-header-group;
+  }
+
+  .link-clicks-table tbody {
+    display: table-row-group;
+  }
+
+  .link-clicks-table tr {
+    display: table-row;
+  }
+
+  .link-clicks-table th,
+  .link-clicks-table td {
+    display: table-cell;
+    padding: 12px 16px;
+    width: auto;
+    border: none;
+  }
+
+  /* Remove any pseudo-elements from the link clicks table */
+  .link-clicks-table td:before,
+  .link-clicks-table th:before {
+    display: none;
+  }
 }

--- a/docs/visits.html
+++ b/docs/visits.html
@@ -2,22 +2,12 @@
 <p>Sorted from most to least recent (max 50)</p>
 
 <link rel=stylesheet href=styles/style.css>
-
-<style>
-table {
-  border: 2px solid black;
-}
-th, td {
-  padding: 5px;
-  max-width: 350px;
-  word-wrap: break-word;
-  border: 2px solid black;
-}
-</style>
+<link rel=stylesheet href=styles/visits.css>
 
 <script type=module>
-  const baseURL = `https://push-notifications-server.glitch.me`;
-  // const baseURL = `http://localhost:8080`;
+  const isLocalhost = location.hostname === 'localhost';
+  const baseURL = isLocalhost ? 'http://localhost:8080' : 'https://push-notifications-server.glitch.me';
+
   (async () => {
     let visits = await fetch(`${baseURL}/visits`);
     visits = await visits.json();
@@ -26,7 +16,7 @@ th, td {
     const tbody = document.querySelector('tbody');
     tbody.innerHTML = '';
     let index = 1;
-    for (const visit of visits.reverse()) {
+    for (const visit of visits) {
       const tr = tbody.appendChild(document.createElement('tr'));
       tr.dataset.id = visit._id;
 
@@ -57,6 +47,56 @@ th, td {
       // Date
       tr.appendChild(document.createElement('td')).innerText = new Date(visit.date).toLocaleString();
 
+      // Link clicks cell
+      const linkClicksCell = tr.appendChild(document.createElement('td'));
+      linkClicksCell.className = 'link-clicks-cell';
+
+      if (visit.linkClicks && visit.linkClicks.length > 0) {
+        const toggleButton = document.createElement('button');
+        toggleButton.className = 'link-clicks-toggle';
+        toggleButton.innerText = `${visit.linkClicks.length} Click${visit.linkClicks.length === 1 ? '' : 's'}`;
+
+        // Create a new row for link clicks content
+        const linkClicksRow = document.createElement('tr');
+        linkClicksRow.className = 'link-clicks-row';
+        const contentCell = document.createElement('td');
+        contentCell.colSpan = 6; // Reduced from 11 to 6 columns
+        contentCell.style.textAlign = 'center'; // Center the table in the available space
+
+        const clicksTable = document.createElement('table');
+        clicksTable.className = 'link-clicks-table';
+
+        // Add header row
+        const thead = clicksTable.createTHead();
+        const headerRow = thead.insertRow();
+        headerRow.innerHTML = `
+          <th>Link Text</th>
+          <th>Click Time</th>
+        `;
+
+        // Add click rows
+        const tbody = clicksTable.createTBody();
+        visit.linkClicks.forEach(click => {
+          const row = tbody.insertRow();
+          row.innerHTML = `
+            <td>${click.text}</td>
+            <td>${new Date(click.date).toLocaleString()}</td>
+          `;
+        });
+
+        contentCell.appendChild(clicksTable);
+        linkClicksRow.appendChild(contentCell);
+        tr.parentNode.insertBefore(linkClicksRow, tr.nextSibling);
+
+        toggleButton.addEventListener('click', () => {
+          linkClicksRow.classList.toggle('active');
+        });
+
+        linkClicksCell.appendChild(toggleButton);
+      } else {
+        linkClicksCell.innerText = 'No clicks';
+      }
+
       // Delete button
       const td = document.createElement('td');
       const button = td.appendChild(document.createElement('button'));
@@ -70,21 +110,24 @@ th, td {
   })();
 </script>
 
-<table>
-  <thead>
-    <tr>
-      <th>#</th>
-      <th>Country</th>
-      <th>City</th>
-      <th>Region</th>
-      <th>ISP</th>
-      <th>IP</th>
-      <th>Referrer</th>
-      <th>Full URL</th>
-      <th>Date</th>
-      <th>Delete</th>
-    </tr>
-  </thead>
-  <tbody>
-  </tbody>
-</table>
+<div class="table-container">
+  <table>
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Country</th>
+        <th>City</th>
+        <th>Region</th>
+        <th>ISP</th>
+        <th>IP</th>
+        <th>Referrer</th>
+        <th>Full URL</th>
+        <th>Date</th>
+        <th>Link Clicks</th>
+        <th>Delete</th>
+      </tr>
+    </thead>
+    <tbody>
+    </tbody>
+  </table>
+</div>

--- a/docs/visits.html
+++ b/docs/visits.html
@@ -106,6 +106,14 @@
         location.reload();
       });
       tr.appendChild(td);
+
+      // Add click handler for expansion
+      tr.addEventListener('click', (e) => {
+        // Don't trigger expansion when clicking buttons
+        if (e.target.tagName !== 'BUTTON') {
+          tr.classList.toggle('expanded');
+        }
+      });
     }
   })();
 </script>

--- a/routes/index.js
+++ b/routes/index.js
@@ -197,6 +197,25 @@ const visitSchema = mongoose.Schema({
   fullUrl: {
     type: String
   },
+  sessionId: {
+    type: String,
+    required: true
+  },
+  date: {
+    type: String,
+    required: true
+  }
+});
+
+const linkClickSchema = mongoose.Schema({
+  sessionId: {
+    type: String,
+    required: true
+  },
+  text: {
+    type: String,
+    required: true
+  },
   date: {
     type: String,
     required: true
@@ -204,17 +223,32 @@ const visitSchema = mongoose.Schema({
 });
 
 const Visits = mongoose.model('Visits', visitSchema);
+const LinkClicks = mongoose.model('LinkClicks', linkClickSchema);
 
 router.get('/visits', async (request, response, next) => {
-  const count = await Visits.countDocuments();
-
   let limit = 50;
   if (request.query.all) {
-    limit = count;
+    limit = await Visits.countDocuments();
   }
 
-  const allVisits = await Visits.find().skip(count - limit);
-  response.json(allVisits);
+  // Get the visits in reverse chronological order (newest first).
+  const allVisits = await Visits.find()
+    .sort({ $natural: -1 })
+    .limit(limit);
+
+  // Create an array of enriched visit objects with their link clicks.
+  const enrichedVisits = await Promise.all(allVisits.map(async visit => {
+    // Find all link clicks for this visit's session.
+    const linkClicks = await LinkClicks.find({ sessionId: visit.sessionId });
+
+    // Convert the Mongoose document to a plain object and add link clicks.
+    const visitObj = visit.toObject();
+    visitObj.linkClicks = linkClicks;
+
+    return visitObj;
+  }));
+
+  response.json(enrichedVisits);
 });
 
 router.get('/deleteVisit', async (request, response, next) => {
@@ -275,10 +309,11 @@ router.get('/getGeoData', async (request, response, next) => {
   }
 });
 
-// TODO(domfarolino): Right now this is just a copy of `/pushOne`. Make this
-// save the link click entry to a database of link clicks.
 router.get('/pushOneForLinkClick', async (request, response, next) => {
   const endpoint = request.query.endpoint;
+  const sessionId = request.query.sessionId;
+  const text = request.query.text;
+
   if (!endpoint) {
     const error = "Must provide an endpoint to notify";
     console.error(error);
@@ -286,11 +321,42 @@ router.get('/pushOneForLinkClick', async (request, response, next) => {
     return;
   }
 
+  if (!sessionId) {
+    const error = "Must provide a sessionId";
+    console.error(error);
+    await sendErrorPushNotification(request, endpoint, error);
+    response.status(400).send(error);
+    return;
+  }
+
+  if (!text) {
+    const error = "Must provide link body text";
+    console.error(error);
+    await sendErrorPushNotification(request, endpoint, error);
+    response.status(400).send(error);
+    return;
+  }
+
   const pushPayload = {
     title: "Link click",
-    text: request.query.text || "Missing link body",
+    text,
     icon: request.query.icon || "https://unsplash.it/200?random"
   };
+
+  // Save the link click to database.
+  const newLinkClick = new LinkClicks({
+    sessionId,
+    text,
+    date: new Date().toISOString(),
+  });
+
+  try {
+    await newLinkClick.save();
+  } catch (e) {
+    console.error(e);
+    await sendErrorPushNotification(request, endpoint, e);
+    return response.status(500).send(e);
+  }
 
   await sendSinglePushHelper(endpoint, pushPayload);
   response.sendStatus(201);
@@ -318,9 +384,18 @@ router.get('/pushOneForLinkClick', async (request, response, next) => {
 // `undefined` in the final push notification.
 router.get('/pushOneForNewVisitor', async (request, response, next) => {
   const endpoint = request.query.endpoint;
+  const sessionId = request.query.sessionId;
+
   if (!endpoint) {
     const error = "Must provide an endpoint to notify";
     console.error(error);
+    return response.status(400).send(error);
+  }
+
+  if (!sessionId) {
+    const error = "Must provide a sessionId";
+    console.error(error);
+    await sendErrorPushNotification(request, endpoint, error);
     return response.status(400).send(error);
   }
 
@@ -351,6 +426,7 @@ router.get('/pushOneForNewVisitor', async (request, response, next) => {
     ip: json.ip,
     referrer: json.referrer,
     fullUrl: json.fullUrl,
+    sessionId: sessionId,
     date: new Date().toISOString(),
   });
 


### PR DESCRIPTION
These helpers are for external applications that use the push notification server as a backend, and this PR augments them to support `sessionId`s which join visits and per-session link clicks. This is most notable for the `https://domfarolino.com` website.

This PR was co-written with Cursor.